### PR TITLE
fix webpack copy snap path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,7 +65,7 @@ const config = {
                 { from: 'meta/version.txt', to: 'meta/version.txt'},
                 { from: 'apiKey.js', noErrorOnMissing: true },
                 { from: 'apiKey-dev.js', noErrorOnMissing: true },
-                { from: '../Snap/src/*.js', to: 'lib/snap/'},
+                { from: '../Snap/src/*.js', to: 'lib/snap/src/[name][ext]', toType: 'template'},
                 { from: '../Snap/locale/lang-zh_CN.js', to: 'lib/snap/locale/lang-zh_CN.js'},
             ]
         })


### PR DESCRIPTION
Fix the webpack in linux copy snap file when the directory error, the reason in [src/index.js#L471](https://github.com/webpack-contrib/copy-webpack-plugin/blob/b66cc95d1e67ca858c46d24fabadbb67f79ab009/src/index.js#L471), when `relativeFrom` is `. /Snap/src`, `path.join(to, relativeFrom)` removes the `snap` from the `to path`, causing this problem. But it happens that the file system is not case-sensitive by default under mac, so it obscures the problem. The solution is to use template to encode `to path`
